### PR TITLE
Fix Kernel::set

### DIFF
--- a/mrblib/sinatic.rb
+++ b/mrblib/sinatic.rb
@@ -135,7 +135,7 @@ module Kernel
     ::Sinatic.content_type type
   end
   def set(key, value)
-    ::Sinatic.set key, type
+    ::Sinatic.set key, value
   end
 end
 


### PR DESCRIPTION
`set(k, v)` was producing the following error:

```
sinatic.rb:138: undefined method 'type' for main (NoMethodError)
```
